### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/src/core/response_context.dart
+++ b/lib/src/core/response_context.dart
@@ -148,7 +148,7 @@ abstract class ResponseContext<RawResponse>
     headers['content-length'] = file.lengthSync().toString();
 
     if (!isBuffered) {
-      await file.openRead().pipe(this);
+      await file.openRead().cast<List<int>>().pipe(this);
     } else {
       buffer.add(file.readAsBytesSync());
       await close();
@@ -320,7 +320,9 @@ abstract class ResponseContext<RawResponse>
         : MediaType.parse(mimeType);
 
     if (correspondingRequest.method != 'HEAD') {
-      return this.addStream(file.openRead()).then((_) => this.close());
+      return this
+          .addStream(file.openRead().cast<List<int>>())
+          .then((_) => this.close());
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angel_framework
-version: 2.0.3
+version: 2.0.3+1
 description: A high-powered HTTP server with dependency injection, routing and much more.
 author: Tobe O <thosakwe@gmail.com>
 homepage: https://github.com/angel-dart/angel_framework


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900