### PR TITLE
Prepare for upcoming Dart SDK breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.4
+* Prepare for Dart SDK change to `Stream<List<int>>` that are now
+  `Stream<Uint8List>`.
+
 # 2.0.3
 * Patch up a bug caused by an upstream change to Dart's stream semantics.
 See more: https://github.com/angel-dart/angel/issues/106#issuecomment-499564485

--- a/lib/src/core/request_context.dart
+++ b/lib/src/core/request_context.dart
@@ -234,7 +234,7 @@ abstract class RequestContext<RawRequest> {
         _uploadedFiles = [];
 
         var parsed = _bodyObject =
-            await body.transform(encoding.decoder).join().then(json.decode);
+            await encoding.decoder.bind(body).join().then(json.decode);
 
         if (parsed is Map) {
           _bodyFields = Map<String, dynamic>.from(parsed);
@@ -244,8 +244,8 @@ abstract class RequestContext<RawRequest> {
       } else if (contentType.type == 'application' &&
           contentType.subtype == 'x-www-form-urlencoded') {
         _uploadedFiles = [];
-        var parsed = await body
-            .transform(encoding.decoder)
+        var parsed = await encoding.decoder
+            .bind(body)
             .join()
             .then((s) => Uri.splitQueryString(s, encoding: encoding));
         _bodyFields = Map<String, dynamic>.from(parsed);
@@ -254,7 +254,7 @@ abstract class RequestContext<RawRequest> {
           contentType.parameters.containsKey('boundary')) {
         var boundary = contentType.parameters['boundary'];
         var transformer = MimeMultipartTransformer(boundary);
-        var parts = body.transform(transformer).map((part) =>
+        var parts = transformer.bind(body).map((part) =>
             HttpMultipartFormData.parse(part, defaultEncoding: encoding));
         _bodyFields = {};
         _uploadedFiles = [];
@@ -334,6 +334,6 @@ class UploadedFile {
 
   /// Reads the contents of the file as [String], using the given [encoding].
   Future<String> readAsString({Encoding encoding = utf8}) {
-    return data.transform(encoding.decoder).join();
+    return encoding.decoder.bind(data).join();
   }
 }

--- a/lib/src/core/response_context.dart
+++ b/lib/src/core/response_context.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:convert' as c show json;
 import 'dart:io' show BytesBuilder, Cookie;
+import 'dart:typed_data';
 
 import 'package:angel_route/angel_route.dart';
 import 'package:file/file.dart';
@@ -148,7 +149,7 @@ abstract class ResponseContext<RawResponse>
     headers['content-length'] = file.lengthSync().toString();
 
     if (!isBuffered) {
-      await file.openRead().pipe(this);
+      await file.openRead().cast<List<int>>().pipe(this);
     } else {
       buffer.add(file.readAsBytesSync());
       await close();
@@ -320,7 +321,9 @@ abstract class ResponseContext<RawResponse>
         : MediaType.parse(mimeType);
 
     if (correspondingRequest.method != 'HEAD') {
-      return this.addStream(file.openRead()).then((_) => this.close());
+      return this
+          .addStream(file.openRead().cast<List<int>>())
+          .then((_) => this.close());
     }
   }
 
@@ -432,12 +435,12 @@ class _LockableBytesBuilderImpl implements LockableBytesBuilder {
   int get length => _buf.length;
 
   @override
-  List<int> takeBytes() {
+  Uint8List takeBytes() {
     return _buf.takeBytes();
   }
 
   @override
-  List<int> toBytes() {
+  Uint8List toBytes() {
     return _buf.toBytes();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angel_framework
-version: 2.0.3
+version: 2.0.4
 description: A high-powered HTTP server with dependency injection, routing and much more.
 author: Tobe O <thosakwe@gmail.com>
 homepage: https://github.com/angel-dart/angel_framework


### PR DESCRIPTION
The SDK recently updated `BytesBuilder.takeBytes()` and
`BytesBuilder.toBytes()` to return `Uint8List` rather than
`List<int>`.
    
A similar change has updated `File.openRead()` to return
`Stream<Uint8List>` and `HttpClientResponse` to implement
`Stream<Uint8List>`.
    
This change makes the corresponding update in the angel framework.
    
https://github.com/dart-lang/sdk/issues/36900
