### PR TITLE
Accept any content type if accept header is missing

### DIFF
--- a/lib/src/core/request_context.dart
+++ b/lib/src/core/request_context.dart
@@ -210,7 +210,7 @@ abstract class RequestContext<RawRequest> {
     _acceptHeaderCache ??= headers.value('accept');
 
     if (_acceptHeaderCache == null) {
-      return false;
+      return true;
     } else if (strict != true && _acceptHeaderCache.contains('*/*')) {
       return true;
     } else {


### PR DESCRIPTION
Fix issue #238. Accept any content type is the request doesn't include an "accept" header, as per RFC 7321.